### PR TITLE
Fix suggestions when e-podroznik returns empty body

### DIFF
--- a/src/EpodroznikClient.php
+++ b/src/EpodroznikClient.php
@@ -110,7 +110,8 @@ final class EpodroznikClient
 
         $respTrim = trim($resp);
         if ($respTrim === '') {
-            throw new \RuntimeException('e‑podroznik.pl zwrócił pustą odpowiedź dla podpowiedzi (suggest.do). Spróbuj ponownie później.');
+            // e‑podroznik sometimes returns HTTP 200 with an empty body when there are no matches.
+            return ['status' => '0', 'suggestions' => []];
         }
 
         try {


### PR DESCRIPTION
Closes #14.

- **Repro:** `GET /api/suggest?q=Warszawa%20qqqqzz` (or e.g. `Wałbrzych Podzamcze`) returned `502` with `{"ok":false,"error":"upstream_error"...}` and the UI showed no feedback.
- **Root cause:** `www.e-podroznik.pl/public/suggest.do` sometimes responds with HTTP 200 and an empty body for queries with no matches; we treated that as an upstream error.
- **Fix:**
  - Treat empty `suggest.do` response body as `suggestions: []` (status `0`).
  - Autocomplete now announces “Brak podpowiedzi.” for empty results and surfaces backend error messages in the live region.

**Verification:**
- `curl -sS "https://podroznik.tyflo.eu.org/api/suggest?q=Warszawa%20qqqqzz&kind=SOURCE&type=ALL"` should return `ok:true` with an empty `suggestions` array after deploy.
- Existing queries like `Wałbrzych 1` still return suggestions.