### PR TITLE
A11y: address Utilitia warnings

### DIFF
--- a/public/assets/app.css
+++ b/public/assets/app.css
@@ -63,9 +63,19 @@ body{
 
 a{color: var(--link);}
 a:visited{color: var(--link-visited);}
-a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible{
+
+a:focus, button:focus, input:focus, select:focus, textarea:focus{
   outline: 3px solid var(--focus);
   outline-offset: 2px;
+}
+@supports selector(:focus-visible){
+  a:focus:not(:focus-visible),
+  button:focus:not(:focus-visible),
+  input:focus:not(:focus-visible),
+  select:focus:not(:focus-visible),
+  textarea:focus:not(:focus-visible){
+    outline: none;
+  }
 }
 
 .skip-link{
@@ -78,7 +88,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
   z-index: 1000;
   border-radius: 8px;
 }
-.skip-link:focus{left: 10px; top: 10px;}
+.skip-link:focus, .skip-link:focus-visible{left: 10px; top: 10px;}
 
 .wrap{max-width: var(--maxw); margin: 0 auto; padding: 0 16px;}
 
@@ -100,6 +110,7 @@ header.site{
   gap: 2px;
 }
 .brand a{color: var(--fg); text-decoration: none;}
+.brand .title, .brand .subtitle{display:block;}
 .brand .title{font-weight: 700; font-size: 1.1rem;}
 .brand .subtitle{color: var(--muted); font-size: 0.95rem;}
 

--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -151,7 +151,6 @@
 
     if (!list || !(list instanceof HTMLElement)) return;
 
-    input.setAttribute('aria-haspopup', 'listbox');
     input.setAttribute('aria-controls', list.id);
     input.setAttribute('aria-expanded', 'false');
 

--- a/src/templates/contact.php
+++ b/src/templates/contact.php
@@ -42,7 +42,7 @@ $reportId = is_array($sent) ? (string)($sent['reportId'] ?? '') : '';
 
       <fieldset>
         <legend>Typ</legend>
-        <div class="stack" role="radiogroup" aria-label="Typ zgłoszenia">
+        <div class="stack">
           <label>
             <input type="radio" name="kind" value="bug" <?= $kind === 'bug' ? 'checked' : '' ?>>
             Błąd
@@ -68,8 +68,8 @@ $reportId = is_array($sent) ? (string)($sent['reportId'] ?? '') : '';
         </div>
 
         <div class="field">
-          <label for="description">Opis</label>
-          <textarea id="description" name="description" rows="8" required><?= \TyfloPodroznik\Html::e($description) ?></textarea>
+          <label id="description_label" for="description">Opis</label>
+          <textarea id="description" name="description" rows="8" required aria-labelledby="description_label"><?= \TyfloPodroznik\Html::e($description) ?></textarea>
           <div class="help">Opisz problem/sugestię i (jeśli to błąd) kroki odtworzenia.</div>
           <?php if (!empty($errors['description'])): ?>
             <div class="error"><?= \TyfloPodroznik\Html::e((string)$errors['description']) ?></div>

--- a/src/templates/layout.php
+++ b/src/templates/layout.php
@@ -13,16 +13,16 @@
 	    <title><?= \TyfloPodroznik\Html::e($title) ?> — Podróżnik Tyflo</title>
 	    <link rel="stylesheet" href="/assets/app.css">
 	    <script src="/assets/app.js" defer></script>
-	  </head>
+  </head>
   <body>
-    <a class="skip-link" href="#main">Przejdź do treści</a>
     <header class="site" role="banner">
+      <a class="skip-link" href="#main">Przejdź do treści</a>
       <div class="wrap">
         <div class="bar">
           <div class="brand">
             <a href="/">
-              <div class="title">Podróżnik Tyflo</div>
-              <div class="subtitle">Dostępna wyszukiwarka połączeń</div>
+              <span class="title">Podróżnik Tyflo</span>
+              <span class="subtitle">Dostępna wyszukiwarka połączeń</span>
             </a>
           </div>
           <nav class="ui-controls" aria-label="Nawigacja">

--- a/src/templates/results.php
+++ b/src/templates/results.php
@@ -51,7 +51,7 @@ foreach (($results['results'] ?? []) as $r) {
         </div>
 
         <?php if ($turnstileRequired && $turnstileSiteKey !== ''): ?>
-          <div class="field" aria-label="Weryfikacja antyspam">
+          <div class="field" role="group" aria-label="Weryfikacja antyspam">
             <div class="help">Weryfikacja antyspam (Cloudflare Turnstile).</div>
             <div class="cf-turnstile" data-sitekey="<?= \TyfloPodroznik\Html::e($turnstileSiteKey) ?>"></div>
             <noscript><div class="error">Aby wysłać formularz, włącz JavaScript (Turnstile).</div></noscript>

--- a/src/templates/search.php
+++ b/src/templates/search.php
@@ -182,8 +182,8 @@ $omitTimeChecked = $timeDefault === '' ? 'checked' : '';
           <label><input type="checkbox" name="prefer_direct" value="1" checked> Preferuj bez przesiadek</label>
           <label><input type="checkbox" name="only_online" value="1"> Tylko bilet online</label>
           <div class="field">
-            <label for="min_change">Minimalny czas na przesiadkę</label>
-            <select id="min_change" name="min_change">
+            <label id="min_change_label" for="min_change">Minimalny czas na przesiadkę</label>
+            <select id="min_change" name="min_change" aria-labelledby="min_change_label">
               <option value="">Domyślny</option>
               <option value="5">Co najmniej 5 minut</option>
               <option value="10">Co najmniej 10 minut</option>
@@ -205,7 +205,7 @@ $omitTimeChecked = $timeDefault === '' ? 'checked' : '';
       </fieldset>
 
       <?php if ($turnstileRequired && $turnstileSiteKey !== ''): ?>
-        <div class="field" aria-label="Weryfikacja antyspam">
+        <div class="field" role="group" aria-label="Weryfikacja antyspam">
           <div class="help">Weryfikacja antyspam (Cloudflare Turnstile).</div>
           <div class="cf-turnstile" data-sitekey="<?= \TyfloPodroznik\Html::e($turnstileSiteKey) ?>"></div>
           <noscript><div class="error">Aby wysłać formularz, włącz JavaScript (Turnstile).</div></noscript>

--- a/src/templates/select_places.php
+++ b/src/templates/select_places.php
@@ -19,7 +19,7 @@ $turnstileSiteKey = (string)($turnstile['siteKey'] ?? '');
 
       <fieldset>
         <legend>Z: <?= \TyfloPodroznik\Html::e($fromQuery) ?></legend>
-        <div class="stack" role="radiogroup" aria-label="Wybór miejsca startu">
+        <div class="stack">
           <?php if (empty($fromSuggestions)): ?>
             <p class="error">Brak podpowiedzi dla pola „Z”. Wróć i spróbuj wpisać inaczej.</p>
           <?php endif; ?>
@@ -43,7 +43,7 @@ $turnstileSiteKey = (string)($turnstile['siteKey'] ?? '');
 
       <fieldset>
         <legend>Do: <?= \TyfloPodroznik\Html::e($toQuery) ?></legend>
-        <div class="stack" role="radiogroup" aria-label="Wybór miejsca docelowego">
+        <div class="stack">
           <?php if (empty($toSuggestions)): ?>
             <p class="error">Brak podpowiedzi dla pola „Do”. Wróć i spróbuj wpisać inaczej.</p>
           <?php endif; ?>
@@ -66,7 +66,7 @@ $turnstileSiteKey = (string)($turnstile['siteKey'] ?? '');
       </fieldset>
 
       <?php if ($turnstileRequired && $turnstileSiteKey !== ''): ?>
-        <div class="field" aria-label="Weryfikacja antyspam">
+        <div class="field" role="group" aria-label="Weryfikacja antyspam">
           <div class="help">Weryfikacja antyspam (Cloudflare Turnstile).</div>
           <div class="cf-turnstile" data-sitekey="<?= \TyfloPodroznik\Html::e($turnstileSiteKey) ?>"></div>
           <noscript><div class="error">Aby wysłać formularz, włącz JavaScript (Turnstile).</div></noscript>

--- a/src/templates/timetable.php
+++ b/src/templates/timetable.php
@@ -67,7 +67,7 @@ $toTime = (string)($defaults['to_time'] ?? '');
 	      </fieldset>
 
       <?php if ($turnstileRequired && $turnstileSiteKey !== ''): ?>
-        <div class="field" aria-label="Weryfikacja antyspam">
+        <div class="field" role="group" aria-label="Weryfikacja antyspam">
           <div class="help">Weryfikacja antyspam (Cloudflare Turnstile).</div>
           <div class="cf-turnstile" data-sitekey="<?= \TyfloPodroznik\Html::e($turnstileSiteKey) ?>"></div>
           <noscript><div class="error">Aby wysłać formularz, włącz JavaScript (Turnstile).</div></noscript>

--- a/src/templates/timetable_select_stop.php
+++ b/src/templates/timetable_select_stop.php
@@ -32,7 +32,7 @@ $turnstileSiteKey = (string)($turnstile['siteKey'] ?? '');
 
       <fieldset>
         <legend>Przystanki</legend>
-        <div class="stack" role="radiogroup" aria-label="Wybór przystanku">
+        <div class="stack">
           <?php foreach ($suggestions as $i => $s): ?>
             <?php
               $label = (string)($s['n'] ?? '');
@@ -52,7 +52,7 @@ $turnstileSiteKey = (string)($turnstile['siteKey'] ?? '');
       </fieldset>
 
       <?php if ($turnstileRequired && $turnstileSiteKey !== ''): ?>
-        <div class="field" aria-label="Weryfikacja antyspam">
+        <div class="field" role="group" aria-label="Weryfikacja antyspam">
           <div class="help">Weryfikacja antyspam (Cloudflare Turnstile).</div>
           <div class="cf-turnstile" data-sitekey="<?= \TyfloPodroznik\Html::e($turnstileSiteKey) ?>"></div>
           <noscript><div class="error">Aby wysłać formularz, włącz JavaScript (Turnstile).</div></noscript>


### PR DESCRIPTION
- Addresses Utilitia warnings from `utilitia-report-json-podroznik-tyflo-eu-org-20260210T105838Z.json`.

Changes:
- Improve focus styling detection: add `:focus` outline with `:focus-visible` fallback (`ace_style_focus_visible`).
- Move skip link inside the banner landmark and ensure it becomes visible on `:focus-visible` too (`ace_aria_content_in_landmark`, `ace_element_tabbable_visible`).
- Remove redundant `aria-haspopup` from autocomplete init (keeps `role=combobox`), to avoid Axe incomplete check noise (`axe_incomplete_aria-valid-attr-value`).
- Add `role="group"` to Turnstile containers using `aria-label` (`axe_incomplete_aria-prohibited-attr`).
- Remove redundant `role="radiogroup"` wrappers around native radios (keeps `fieldset/legend`) (`ace_aria_keyboard_handler_exists`).
- Add explicit `aria-labelledby` for a couple of labeled controls that were still flagged for manual verification (`ace_input_label_visible`).
- Change header brand markup (`div.title` → `span.title`) to reduce heading-heuristic warnings (`ace_text_block_heading`).

Notes:
- `ace_style_color_misuse` is a generic manual-check warning and likely remains.