### PR TITLE
A11y: reduce duplicate reading on mobile SR

### DIFF
--- a/public/assets/app.css
+++ b/public/assets/app.css
@@ -225,6 +225,12 @@ fieldset{
 }
 legend{font-weight: 700; padding: 0 6px;}
 
+summary{
+  cursor: pointer;
+  font-weight: 700;
+}
+details[open] > summary{margin-bottom: var(--gap);}
+
 .grid-2{display: grid; gap: var(--gap);}
 @media (min-width: 820px){
   .grid-2{grid-template-columns: 1fr 1fr;}

--- a/src/templates/layout.php
+++ b/src/templates/layout.php
@@ -30,12 +30,12 @@
             <a class="btn small" href="/timetable">Rozkład z przystanku</a>
             <a class="btn small" href="/contact">Zgłoś problem</a>
           </nav>
-          <form class="ui-controls" method="post" action="/ui" aria-label="Ustawienia wyglądu">
+          <form class="ui-controls" method="post" action="/ui">
             <input type="hidden" name="csrf" value="<?= \TyfloPodroznik\Html::e($csrf) ?>">
             <input type="hidden" name="back" value="<?= \TyfloPodroznik\Html::e(parse_url((string)($_SERVER['REQUEST_URI'] ?? '/'), PHP_URL_PATH) ?: '/') ?>">
             <button class="btn small" type="submit" name="action" value="toggle_contrast">Kontrast</button>
-            <button class="btn small" type="submit" name="action" value="font_dec" aria-label="Zmniejsz czcionkę">A−</button>
-            <button class="btn small" type="submit" name="action" value="font_inc" aria-label="Zwiększ czcionkę">A+</button>
+            <button class="btn small" type="submit" name="action" value="font_dec">Czcionka −</button>
+            <button class="btn small" type="submit" name="action" value="font_inc">Czcionka +</button>
           </form>
         </div>
       </div>
@@ -43,7 +43,7 @@
 
     <main id="main" class="wrap" tabindex="-1">
       <?php if (is_array($flash) && isset($flash['message'])): ?>
-        <div class="card stack" role="status" aria-live="polite">
+        <div class="card stack">
           <strong class="<?= \TyfloPodroznik\Html::e((string)($flash['level'] ?? '')) ?>">
             <?= \TyfloPodroznik\Html::e((string)$flash['message']) ?>
           </strong>
@@ -55,9 +55,8 @@
 
     <footer class="site">
       <div class="wrap">
-        <p>
-          Źródło danych: <a href="https://www.e-podroznik.pl/">e‑podroznik.pl</a>. To jest niezależny frontend ukierunkowany na dostępność.
-        </p>
+        <p><a href="https://www.e-podroznik.pl/">Źródło danych: e‑podroznik.pl</a></p>
+        <p class="help">To jest niezależny frontend ukierunkowany na dostępność.</p>
       </div>
     </footer>
   </body>

--- a/src/templates/results.php
+++ b/src/templates/results.php
@@ -22,9 +22,7 @@ foreach (($results['results'] ?? []) as $r) {
   <h1>Wyniki wyszukiwania</h1>
 
   <div class="card stack">
-    <div>
-      <strong>Liczba wyników:</strong> <?= $count ?>
-    </div>
+    <div>Liczba wyników: <?= $count ?></div>
     <?php if ($count === 0): ?>
       <div class="help">
         Brak wyników dla wybranych ustawień. Spróbuj zaznaczyć inne środki transportu albo wyłączyć „Preferuj bez przesiadek”.
@@ -99,17 +97,18 @@ foreach (($results['results'] ?? []) as $r) {
         <h3>
           <?= \TyfloPodroznik\Html::e($fromTime) ?> <?= \TyfloPodroznik\Html::e($fromStop) ?>
           → <?= \TyfloPodroznik\Html::e($toTime) ?> <?= \TyfloPodroznik\Html::e($toStop) ?>
-          <?php if ($duration !== ''): ?>
-            <span class="meta">(<?= \TyfloPodroznik\Html::e($duration) ?>)</span>
-          <?php endif; ?>
+          <?php if ($duration !== ''): ?> (<?= \TyfloPodroznik\Html::e($duration) ?>)<?php endif; ?>
         </h3>
-        <div class="help">
-          <?php if ($dateInfo !== ''): ?>
-            <?= \TyfloPodroznik\Html::e($dateInfo) ?> •
-          <?php endif; ?>
-          Przesiadki: <?= (int)$changes ?> •
-          Bilet online: <?= $sellable ? '<span class="ok">możliwy</span>' : '<span class="warn">brak / niedostępny</span>' ?>
-        </div>
+        <?php
+          $metaParts = [];
+          if ($dateInfo !== '') {
+            $metaParts[] = $dateInfo;
+          }
+          $metaParts[] = 'Przesiadki: ' . (int)$changes;
+          $metaParts[] = 'Bilet online: ' . ($sellable ? 'możliwy' : 'brak / niedostępny');
+          $metaText = implode(' • ', $metaParts);
+        ?>
+        <div class="help"><?= \TyfloPodroznik\Html::e($metaText) ?></div>
         <div class="actions">
           <?php if ($resId !== ''): ?>
             <a class="btn" href="<?= \TyfloPodroznik\Html::url('/result', ['id' => $resId]) ?>">Szczegóły</a>

--- a/src/templates/search.php
+++ b/src/templates/search.php
@@ -11,7 +11,7 @@ $omitTimeChecked = $timeDefault === '' ? 'checked' : '';
   <h1>Wyszukiwarka połączeń</h1>
 
   <div class="card">
-    <form method="post" action="/search" class="stack" novalidate aria-label="Wyszukiwanie połączeń">
+    <form method="post" action="/search" class="stack" novalidate>
       <input type="hidden" name="csrf" value="<?= \TyfloPodroznik\Html::e($csrf) ?>">
 
       <fieldset class="grid-2">
@@ -92,7 +92,7 @@ $omitTimeChecked = $timeDefault === '' ? 'checked' : '';
 	            <input type="checkbox" name="omit_time" value="1" <?= $omitTimeChecked ?>>
 	            Pomiń godzinę (pokaż połączenia z całego dnia)
           </label>
-          <div class="help">Jeśli podasz godzinę, „Pomiń godzinę” zostanie zignorowane.</div>
+          <div class="help">Jeśli podasz godzinę, pokażemy połączenia od tej godziny.</div>
         </div>
       </fieldset>
 
@@ -172,8 +172,8 @@ $omitTimeChecked = $timeDefault === '' ? 'checked' : '';
         })();
       </script>
 
-      <fieldset>
-        <legend>Ustawienia wyszukiwania</legend>
+      <details class="card">
+        <summary>Ustawienia wyszukiwania (opcjonalnie)</summary>
         <div class="stack">
           <label><input type="checkbox" name="prefer_direct" value="1" checked> Preferuj bez przesiadek</label>
           <label><input type="checkbox" name="only_online" value="1"> Tylko bilet online</label>
@@ -198,10 +198,10 @@ $omitTimeChecked = $timeDefault === '' ? 'checked' : '';
             </div>
           </fieldset>
         </div>
-      </fieldset>
+      </details>
 
       <?php if ($turnstileRequired && $turnstileSiteKey !== ''): ?>
-        <div class="field" role="group" aria-label="Weryfikacja antyspam">
+        <div class="field">
           <div class="help">Weryfikacja antyspam (Cloudflare Turnstile).</div>
           <div class="cf-turnstile" data-sitekey="<?= \TyfloPodroznik\Html::e($turnstileSiteKey) ?>"></div>
           <noscript><div class="error">Aby wysłać formularz, włącz JavaScript (Turnstile).</div></noscript>


### PR DESCRIPTION
Zmniejsza „podwójne”/rozdzielone odczyty na mobile z czytnikiem ekranu.

- Wyniki: meta (dzień/przesiadki/bilet) jest jednym tekstem bez zagnieżdżonych `<span>`; czas trwania jest tekstem (bez osobnego elementu), a „Liczba wyników” nie jest rozbita na `<strong>` + liczba.
- Layout: usuwa zbędne `aria-label`/`aria-live` w header/footer i rozdziela stopkę tak, żeby link nie był czytany jako część dłuższego akapitu.
- Wyszukiwanie: „Ustawienia wyszukiwania” przeniesione do `<details>` (mniej elementów do przewijania) i krótszy komunikat o godzinie.
